### PR TITLE
Added more helper functions for increased flexbility

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,19 @@ app.use(manifestHelpers({
 `javascriptTag(source, attrs)` - return a script tag for the source provided
 
 `stylesheetTag(source, attrs)` - return a link tag for the source provided
+
+`getManifest()` - returns the original manifest file for convenience
+
+`getSources()` - returns a list of sources from the manifest
+
+`getStylesheetSources()` - returns a list of all sources ending with `.css`
+
+`getStylesheets()` - returns a list of all stylesheets and their resolved paths
+
+`getJavascriptSources()` - returns a list of all sources ending with `.js`
+
+`getJavascripts()` - returns a list of all javascripts and their resolved paths
+
+`getImageSources()` - returns a list of all sources ending with `.jpg`, `.jpeg`, `.gif`, `.png`, `.bmp` or `.webp`, 
+
+`getImages()` - returns a list of all images and their resolved paths

--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,13 @@ export default function(opts) {
   assign(options, defaults, opts)
 
   return function(req, res, next) {
+    res.locals.getSources = getSources
+    res.locals.getStylesheetSources = getStylesheetSources
+    res.locals.getStylesheets = getStylesheets
+    res.locals.getJavascriptSources = getJavascriptSources
+    res.locals.getJavascripts = getJavascripts
+    res.locals.getImageSources = getImageSources
+    res.locals.getImages = getImages
     res.locals.getManifest = getManifest
     res.locals.assetPath = assetPath
     res.locals.imageTag = imageTag

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,39 @@ export function trimTag(str){
     .replace(/  \/>/, ' />')
 }
 
+export function getManifest() {
+  return manifest || loadManifest()
+}
+
+export function getSources() {
+  manifest = manifest || loadManifest();
+  return Object.keys(manifest);
+}
+
+export function getStylesheetSources() {
+  return getSources().filter((file) => file.match(/\.css$/));
+}
+
+export function getStylesheets() {
+  return getStylesheetSources().map((source) => lookup(source));
+}
+
+export function getJavascriptSources() {
+  return getSources().filter((file) => file.match(/\.js$/));
+}
+
+export function getJavascripts() {
+  return getJavascriptSources().map((source) => lookup(source));
+}
+
+export function getImageSources() {
+  return getSources().filter((file) => file.match(/\.(png|jpe?g|gif|webp|bmp)$/));
+}
+
+export function getImages() {
+  return getImageSources().map((source) => lookup(source));
+}
+
 export function assetPath(source) {
   return lookup(source)
 }
@@ -64,6 +97,7 @@ export default function(opts) {
   assign(options, defaults, opts)
 
   return function(req, res, next) {
+    res.locals.getManifest = getManifest
     res.locals.assetPath = assetPath
     res.locals.imageTag = imageTag
     res.locals.javascriptTag = javascriptTag

--- a/test/files-list.spec.js
+++ b/test/files-list.spec.js
@@ -1,0 +1,78 @@
+import fs from 'fs'
+
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import manifestHelpers from '../src'
+import {
+  getSources,
+  getStylesheetSources,
+  getStylesheets,
+  getJavascriptSources,
+  getJavascripts,
+  getImageSources,
+  getImages
+} from '../src'
+
+describe('#getListOfFiles', function(){
+  const manifestPath = 'some/path/manifest.json'
+  const javascripts = {
+    'file.js': 'file.5678.min.js',
+    'file2.js': 'file.1234.min.js',
+  };
+  const stylesheets = {
+    'file3.css': 'file.2345.min.css'
+  }
+  const images = {
+    'test.jpg': 'test.1234.jpg',
+    'test.jpeg': 'test.1234.jpeg',
+    'test.gif': 'test.1234.gif',
+    'test.png': 'test.1234.png',
+    'test.bmp': 'test.1234.bmp',
+    'test.webp': 'test.1234.webp',
+  }
+  const manifest = Object.assign({}, javascripts, stylesheets, images);
+
+  beforeEach(function(){
+    sinon.stub(fs, 'readFileSync')
+      .returns(JSON.stringify(manifest))
+    manifestHelpers({ manifestPath })
+  })
+
+  afterEach(function(){
+    fs.readFileSync.restore()
+  })
+
+  it('exists', function(){
+    expect(getStylesheets).to.exist
+    expect(getJavascripts).to.exist
+    expect(getImages).to.exist
+    expect(getSources).to.exist
+  })
+
+  it('returns a list of all source files', function(){
+    let sources = getSources()
+    expect(sources).to.deep.equal(Object.keys(manifest));
+  })
+
+  it('returns a list of all javascript files', function(){
+    let jsFiles = getJavascripts();
+    let jsSources = getJavascriptSources()
+    expect(jsFiles).to.deep.equal(Object.values(javascripts));
+    expect(jsSources).to.deep.equal(Object.keys(javascripts));
+  })
+
+  it('returns a list of all css files', function(){
+    let cssFiles = getStylesheets();
+    let cssSources = getStylesheetSources()
+    expect(cssFiles).to.deep.equal(Object.values(stylesheets));
+    expect(cssSources).to.deep.equal(Object.keys(stylesheets));
+  })
+
+  it('returns a list of all image files', function(){
+    let imgFiles = getImages();
+    let imgSources = getImageSources()
+    expect(imgFiles).to.deep.equal(Object.values(images));
+    expect(imgSources).to.deep.equal(Object.keys(images));
+  })
+})


### PR DESCRIPTION
Hey, first of all: great package, turned out to be very helpful in several projects!

I am generating a manifest file for bundles and chunks dynamically via webpack. Since I don't know their (source) names, I was unable to do a `res.locals.assetPath()` for every file without reading the manifest file again, iterating manually through the list of files so I added this functionality to your package.

(Constructed) basic example:
```js
app.use(manifestHelpers({ manifestPath: './build/manifest.json' }));

app.use('*', (req, res) => {
    res.send(`
    <html>
    <head>
    ${res.locals
        .getStylesheets()
        .map(cssFile => '<link href=' + cssFile + ' rel="stylesheet" />')
        .join('')}
    ${res.locals
        .getJavascripts()
        .map(jsFile => '<script src=' + jsFile + '></script>')
        .join('')}
    </head>
    <body>[…]</body>
    </html>
    `);
});
```

Alternatively this would also work of course:
```js
const stylesheets = res.locals.getStylesheetSources().map(res.locals.stylesheetTag).join('')
```

**Output:**
```html
<html>
<head>
<link href=/static/bundle.css rel="stylesheet" />
<script src=/static/bundle.js></script><script src=/static/vendor.61829cb8.chunk.js></script>
</head>
<body>[…]</body>
</html>
```

Hope you like it!