### PR TITLE
Update lodash due to possible security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "sinon": "^1.14.1"
   },
   "dependencies": {
-    "lodash": "^3.9.1"
+    "lodash": "^4.17.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import assign from 'lodash/object/assign'
+import assign from 'lodash/assign'
 
 var manifest
 var options = {}


### PR DESCRIPTION
Source: https://www.npmjs.com/advisories/577

Lodash versions prior to 4.17.5 are affected so I updated it to 4.17.10. Tests are all still passing so I think this could be safely merged.